### PR TITLE
Refactor ingredients-recipes relationship

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,6 +1,8 @@
 class Ingredient < ApplicationRecord
   validates :name, presence: true
+  validates :quantity_grams, numericality: { only_integer: true, greater_than: 0 }
+  validates :quantity_ml, numericality: { only_integer: true, greater_than: 0 }
+  validates :preparation_method, length: { maximum: 255 }
 
-  has_many :preparations
-  has_many :recipes, through: :preparations
+  belongs_to :recipe
 end

--- a/db/migrate/20241214081332_add_quantities_to_ingredients.rb
+++ b/db/migrate/20241214081332_add_quantities_to_ingredients.rb
@@ -1,0 +1,8 @@
+class AddQuantitiesToIngredients < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ingredients, :quantity_grams, :integer
+    add_column :ingredients, :quantity_ml, :integer
+    add_column :ingredients, :preparation_method, :text, limit: 255
+    add_reference :ingredients, :recipe, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_13_161939) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_14_081332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_161939) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "quantity_grams"
+    t.integer "quantity_ml"
+    t.text "preparation_method"
+    t.bigint "recipe_id"
+    t.index ["recipe_id"], name: "index_ingredients_on_recipe_id"
   end
 
   create_table "preparations", force: :cascade do |t|
@@ -48,6 +53,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_161939) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "ingredients", "recipes"
   add_foreign_key "preparations", "ingredients"
   add_foreign_key "preparations", "recipes"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :preparation do
-    recipe { FactoryBot.create(:recipe) }
     ingredient { FactoryBot.create(:ingredient) }
+    recipe { FactoryBot.create(:recipe) }
     quantity_unit { Faker::Food.measurement }
     quantity_amount { Faker::Number.decimal(l_digits: 1, r_digits: 2) }
     quantity_grams { Faker::Number.number(digits: 4) }
@@ -11,6 +11,10 @@ FactoryBot.define do
 
   factory :ingredient do
     name { Faker::Food.ingredient }
+    recipe { FactoryBot.create(:recipe) }
+    quantity_grams { Faker::Number.number(digits: 4) }
+    quantity_ml { Faker::Number.number(digits: 4) }
+    preparation_method { Faker::Food.description }
   end
 
   factory(:recipe) do

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -8,5 +8,22 @@ RSpec.describe Ingredient, type: :model do
       subject.name = nil
       is_expected.not_to be_valid
     end
+
+    it 'has no recipe reference' do
+      ingredient.recipe = nil
+      is_expected.to_not be_valid
+    end
+
+    it 'has no ingredient reference' do
+      ingredient.recipe = nil
+      is_expected.to_not be_valid
+    end
+
+    context 'when preparation method length is greater than 255' do
+      it do
+        ingredient.preparation_method = Faker::Lorem.characters(number: 256)
+        is_expected.to_not be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
After review the database that will seed the app, it will demand some regex-like feature to extract the serialize information to split the info along three different tables (Recipes, Preparations, Ingredients). 
Based on this complexity for now, it was opted to continue with a simpler approach with just two tables.